### PR TITLE
fix: ログイン状態では遷移できない画面を定義

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -1,7 +1,13 @@
+<script setup lang="ts">
+import { useAuthUserStore } from '~~/stores/authUser';
+const store = useAuthUserStore();
+const isLogin = ref(store.authUser?.user);
+</script>
+
 <template>
   <footer class="footer p-10 pb-20 md:pb-10 bg-neutral text-base-content mt-auto">
     <div>
-      <NuxtLink to="/">
+      <NuxtLink :to="isLogin ? '/home' : '/'">
         <div class="text-4xl text-yellow-100">Huddle</div>
         <div class="text-4xl text-yellow-100">Guide</div>
       </NuxtLink>
@@ -9,7 +15,7 @@
     <div>
       <NuxtLink to="/terms" class="link link-hover text-xl text-yellow-100">利用規約</NuxtLink>
       <NuxtLink to="/policy" class="link link-hover text-xl text-yellow-100">プライバシーポリシー</NuxtLink>
-      <!-- <NuxtLink to="#" class="link link-hover text-xl text-yellow-100">クイックガイド</NuxtLink> -->
+      <NuxtLink to="/about" class="link link-hover text-xl text-yellow-100">Huddle Guideとは</NuxtLink>
       <a class="link link-hover text-xl text-yellow-100" target="_blank" href="https://twitter.com/da_yoshi_k">お問合せ</a>
     </div>
   </footer>

--- a/middleware/loginAccessControl.global.ts
+++ b/middleware/loginAccessControl.global.ts
@@ -4,7 +4,9 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const route = useRoute();
   const authUser = await store.fetchAuthUser();
 
-  if (route.meta.requireLogin === true && !authUser && to.path !== '/login') {
+  if (route.meta.requireLogin && !authUser && to.path !== '/login') {
     return navigateTo('/login');
+  } else if (route.meta.noLoginAccess && authUser && to.path !== '/home') {
+    return navigateTo('/home');
   }
 });

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -1,30 +1,14 @@
 <script setup lang="ts">
 definePageMeta({
-  noLoginAccess: true,
   layout: "static",
 });
 </script>
 
 <template>
   <div class="text-center">
-    <div class="top-container pt-5 grid grid-cols-1 md:grid-cols-2">
-      <div class="flex justify-center md:justify-end md:mr-4">
-        <img class="object-contain" src="/img/top_banner.png" alt="huddle-guide brand banner">
-      </div>
-      <div class="flex justify-center row-span-3 md:justify-start md:ml-4 max-w-lg">
-        <img class="object-contain justify-center" src="/img/top_discussion.svg" alt="discussion image">
-      </div>
-      <div class="flex justify-center md:justify-end md:mr-16">
-        <p class="pt-6 text-3xl">オンラインでもチームで<br>コミュニケーションが<br>取れていますか？</p>
-      </div>
-      <div class="my-6 flex justify-center md:justify-end md:mr-16">
-        <NuxtLink to="/register" class="btn btn-active brn-primary shadow text-sm md:text-lg text-base-100 mr-12">
-          使ってみる
-        </NuxtLink>
-        <NuxtLink to="/login" class="btn brn-neutral shadow text-sm md:text-lg text-base-100 ml-12">
-          ログイン
-        </NuxtLink>
-      </div>
+    <div class="pt-24 text-3xl font-bold">Huddle Guideとは</div>
+    <div>
+      <p class="py-6">Huddle Guideはチームメンバーの共通点を発見したり、<br />日々あった新しいことを共有するような<br />複数の同期型のワークを提供するサービスです</p>
     </div>
     <div class="pt-24 text-3xl font-bold">使い方</div>
     <div class="hero bg-base-100">
@@ -58,14 +42,6 @@ definePageMeta({
           </div>
         </div>
       </div>
-    </div>
-    <div class="my-6 flex justify-center">
-      <NuxtLink to="/register" class="btn btn-active brn-primary shadow text-sm md:text-lg text-base-100 mr-12">
-        使ってみる
-      </NuxtLink>
-      <NuxtLink to="/login" class="btn brn-neutral shadow text-sm md:text-lg text-base-100 ml-12">
-        ログイン
-      </NuxtLink>
     </div>
     <div class="text-right">
       <a href="https://storyset.com/research" class="link-hover text-info text-xs mr-2">Illustration by Storyset</a>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -26,6 +26,7 @@ const login = handleSubmit(async () => {
 });
 
 definePageMeta({
+  noLoginAccess: true,
   layout: "static",
 });
 </script>

--- a/pages/profile/index.vue
+++ b/pages/profile/index.vue
@@ -85,7 +85,7 @@ definePageMeta({
             </ValidationField>
           </div>
           <div class="form-control">
-            <label for="name" class="label">
+            <label for="description" class="label">
               <span class="label-text">自己紹介（400字まで）</span>
             </label>
             <ValidationField name="自己紹介" v-model="description" rules="max:400" v-slot="{ errors, handleChange }">

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -32,6 +32,7 @@ const register = handleSubmit(async () => {
 });
 
 definePageMeta({
+  noLoginAccess: true,
   layout: "static",
 });
 </script>


### PR DESCRIPTION
https://github.com/da-yoshi-k/huddle-guide/issues/68
上記Issueに対応するための下記対応を行いました。

- トップページおよびログイン・新規登録画面は未ログイン時しか遷移できないように修正する。
- グローバルフッターのリンク先もヘッダーのバナー同様に分ける。
- aboutページ（Huddle Guideとはページ）を作成し、フッターに追加する