### PR TITLE
画面の遷移時に明示的にcableを破棄するように処理を追加

### DIFF
--- a/components/work/SelectModal.vue
+++ b/components/work/SelectModal.vue
@@ -33,13 +33,13 @@ const handleStandbyWork = () => {
       <h3 class="text-xl font-bold mb-4">ワーク開始</h3>
       <p>実施するワーク: {{ props.work.name }}</p>
       <p class="py-4">ワークを行うチームを選択してください</p>
-      <form>
+      <form @submit.prevent>
         <select v-model="selectedTeamId" class="select select-bordered w-full max-w-xs">
           <option v-for="item in props.teams" :key="item.id" :value="item.id">{{ item.name }}</option>
         </select>
         <span class="text-error" v-if="!!disabled"><br />チームに参加していない場合にはワークを開始できません。</span>
         <div class="flex justify-center mt-4">
-          <div class="btn btn-primary text-white" :class="disabled" @click="handleStandbyWork">ワークを開始</div>
+          <button class="btn btn-primary text-white" :class="disabled" @click="handleStandbyWork">ワークを開始</button>
         </div>
       </form>
     </label>

--- a/pages/works/find-similarities/[id]/index.vue
+++ b/pages/works/find-similarities/[id]/index.vue
@@ -11,7 +11,11 @@ const store = useWorkshopStore();
 const authUserStore = useAuthUserStore();
 const route = useRoute();
 const runTimeConfig = useRuntimeConfig();
-const cable = ActionCable.createConsumer(runTimeConfig.public.actioncableUrl)
+const cable = ActionCable.createConsumer(runTimeConfig.public.actioncableUrl);
+if (cable == null) {
+  console.log('接続に失敗しました');
+}
+
 await store.fetchWorkshop(route.params.id as string).then(() => {
   if (store.workshop?.workshop.work_step.name === '終了') {
     navigateTo(`/works/find-similarities/${store.workshop?.workshop.id}/complete`)
@@ -52,6 +56,7 @@ const workshopChannel = cable.subscriptions.create(
         case 'end_workshop':
           notify({ type: "info", text: "ワークショップが終了されました。<br /> 5秒後に終了画面に遷移します。", duration: 4500 })
           workshopChannel.unsubscribe();
+          cable.disconnect();
           setTimeout(() => {
             navigateTo(`/works/find-similarities/${store.workshop?.workshop.id}/complete`)
           }, 5000);

--- a/pages/works/find-similarities/[id]/standby.vue
+++ b/pages/works/find-similarities/[id]/standby.vue
@@ -8,6 +8,10 @@ const route = useRoute();
 const MIN_MEMBER_COUNT = 1;
 const runTimeConfig = useRuntimeConfig();
 const cable = ActionCable.createConsumer(runTimeConfig.public.actioncableUrl)
+if (cable == null) {
+  console.log('接続に失敗しました');
+}
+
 await store.fetchWorkshop(route.params.id as string).then(() => {
   if (store.workshop?.workshop.work_step.name === '終了') {
     navigateTo(`/works/find-similarities/${store.workshop?.workshop.id}/complete`)
@@ -26,7 +30,8 @@ const workshopStandbyChannel = cable.subscriptions.create(
           break
         case 'start_workshop':
           notify({ type: "info", text: "ワークが開始されました。", duration: 1000 })
-          workshopStandbyChannel.unsubscribe()
+          workshopStandbyChannel.unsubscribe();
+          cable.disconnect();
           setTimeout(() => {
             navigateTo(`/works/find-similarities/${store.workshop?.workshop.id}`)
           }, 500);


### PR DESCRIPTION
下記のIssueと関連して、クライアントサイドでsubscriptionの破棄までしか行っていなかったものを、
cableのインスタンスを破棄するように明示的に処理を追加しました。
（cableのコネクション自体は残ったままで、それがupstash redisのタイムアウトと競合していたという仮説）
https://github.com/da-yoshi-k/huddle-guide/issues/84