### PR TITLE
タイマーコンポーネントの実装と時間が表示されないバグへの対処

### DIFF
--- a/components/work/CountupTimer.vue
+++ b/components/work/CountupTimer.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import dayjs from 'dayjs';
+const props = defineProps<{
+  time: string | null,
+  title: string
+}>()
+
+let formatElapsedTime = ref('--:--')
+
+const setFormatElapsedTime = () => {
+  setInterval(() => {
+    if (!props.time) {
+      return
+    }
+    const dateStr = (new Date).toString()
+    const diff = dayjs(dateStr).diff(dayjs(props.time), 'second')
+    formatElapsedTime.value = `${diff / 60 | 0}:${('0' + diff % 60).slice(-2)}`
+  }, 1000)
+}
+setFormatElapsedTime()
+</script>
+
+<template>
+  <div class="flex flex-col justify-center items-center">
+    <div class="text-sm">{{ props.title }}</div>
+    <div class="text-right">{{ formatElapsedTime }}</div>
+  </div>
+</template>

--- a/components/work/CountupTimer.vue
+++ b/components/work/CountupTimer.vue
@@ -4,19 +4,21 @@ const props = defineProps<{
   time: string | null,
   title: string
 }>()
-
+const nuxtApp = useNuxtApp();
 let formatElapsedTime = ref('--:--')
 
 const setFormatElapsedTime = () => {
   setInterval(() => {
     if (!props.time) {
+      formatElapsedTime.value = '--:--'
       return
     }
     const dateStr = (new Date).toString()
-    const diff = dayjs(dateStr).diff(dayjs(props.time), 'second')
+    const diff = dayjs(dateStr).diff(nuxtApp.$validDate(props.time), 'second')
     formatElapsedTime.value = `${diff / 60 | 0}:${('0' + diff % 60).slice(-2)}`
   }, 1000)
 }
+// コンポーネントが存在する場合には常に実行
 setFormatElapsedTime()
 </script>
 

--- a/pages/works/find-similarities/[id]/index.vue
+++ b/pages/works/find-similarities/[id]/index.vue
@@ -152,12 +152,16 @@ definePageMeta({
     <div class="flex justify-center w-full">
       <div class="w-full max-w-6xl">
         <div class="flex flex-col">
-          <h2 class="font-bold leading-tight text-2xl text-black m-4">共通点探し</h2>
+          <div class="flex">
+            <h2 class="font-bold leading-tight text-2xl text-black m-4">共通点探し</h2>
+            <WorkCountupTimer :title="'ワーク経過時間'" :time="store.workshop!.workshop.work_start_time" class="ml-auto mr-6" />
+          </div>
           <WorkStepList :step="workStep" />
           <div class="ml-8 flex gap-4 flex-wrap">
             <WorkFacilitatorCard :user="facilitator!" />
             <WorkPresenterCard :user="presenter" :work_step="store.workshop!.workshop.work_step.name"
               @next-presenter="nextPresenter" />
+            <WorkCountupTimer :title="'発表時間'" :time="store.workshop!.workshop.turn_start_time" />
             <div class="flex items-center md:ml-auto mr-8">
               <WorkNextStepButton :step="workStep" @next-step="handleWorkStep" @end-work="handleEndWorkshop" />
             </div>

--- a/pages/works/find-similarities/[id]/standby.vue
+++ b/pages/works/find-similarities/[id]/standby.vue
@@ -54,6 +54,7 @@ const disabled = computed(() => {
 })
 
 const startWorkshop = async () => {
+  await store.startWorkshop()
   await store.updateWorkStep(2).then(() => {
     workshopStandbyChannel.perform('start_workshop', {})
   })

--- a/plugins/dayjs.client.ts
+++ b/plugins/dayjs.client.ts
@@ -3,8 +3,11 @@ import dayjs from 'dayjs';
 export default defineNuxtPlugin(() => {
   return {
     provide: {
-      formatDate: (inputDate: Date) => {
-        return dayjs(inputDate).format('YYYY-MM-DD');
+      formatDate: (inputDate: string) => {
+        return dayjs(inputDate.replace(/\s\+\d{4}$/, '')).format('YYYY-MM-DD');
+      },
+      validDate: (inputDate: string) => {
+        return dayjs(inputDate.replace(/\s\+\d{4}$/, ''));
       },
     },
   };

--- a/plugins/dayjs.client.ts
+++ b/plugins/dayjs.client.ts
@@ -4,10 +4,12 @@ export default defineNuxtPlugin(() => {
   return {
     provide: {
       formatDate: (inputDate: string) => {
-        return dayjs(inputDate.replace(/\s\+\d{4}$/, '')).format('YYYY-MM-DD');
+        return dayjs(inputDate.replace(/\s[-+]\d{4}$/, '')).format(
+          'YYYY-MM-DD'
+        );
       },
       validDate: (inputDate: string) => {
-        return dayjs(inputDate.replace(/\s\+\d{4}$/, ''));
+        return dayjs(inputDate.replace(/\s[-+]\d{4}$/, ''));
       },
     },
   };

--- a/stores/workShop.ts
+++ b/stores/workShop.ts
@@ -47,10 +47,12 @@ export const useWorkshopStore = defineStore('workshop', {
         }
       }
       this.workshop!.workshop.presenter = nextPresenter;
+      const startTime = new Date();
       const options = useApiFetchOption();
       const param = {
         workshop: {
           presenter: nextPresenter,
+          turn_start_time: startTime,
         },
       };
       await useFetch(`workshops/${this.workshop!.workshop.id}`, {
@@ -142,6 +144,21 @@ export const useWorkshopStore = defineStore('workshop', {
         ...options,
       });
       this.workshop!.workshop.work_step_id = stepNum;
+    },
+    async startWorkshop() {
+      const options = useApiFetchOption();
+      const startTime = new Date();
+      const bodyParam = {
+        workshop: {
+          work_start_time: startTime,
+        },
+      };
+      await useFetch(`workshops/${this.workshop!.workshop.id}`, {
+        method: 'PATCH',
+        body: bodyParam,
+        ...options,
+      });
+      this.workshop!.workshop.work_start_time = startTime.toString();
     },
     async fetchMessages() {
       const options = useApiFetchOption();

--- a/stores/workshop.ts
+++ b/stores/workshop.ts
@@ -47,10 +47,12 @@ export const useWorkshopStore = defineStore('workshop', {
         }
       }
       this.workshop!.workshop.presenter = nextPresenter;
+      const startTime = new Date();
       const options = useApiFetchOption();
       const param = {
         workshop: {
           presenter: nextPresenter,
+          turn_start_time: startTime,
         },
       };
       await useFetch(`workshops/${this.workshop!.workshop.id}`, {
@@ -142,6 +144,21 @@ export const useWorkshopStore = defineStore('workshop', {
         ...options,
       });
       this.workshop!.workshop.work_step_id = stepNum;
+    },
+    async startWorkshop() {
+      const options = useApiFetchOption();
+      const startTime = new Date();
+      const bodyParam = {
+        workshop: {
+          work_start_time: startTime,
+        },
+      };
+      await useFetch(`workshops/${this.workshop!.workshop.id}`, {
+        method: 'PATCH',
+        body: bodyParam,
+        ...options,
+      });
+      this.workshop!.workshop.work_start_time = startTime.toString();
     },
     async fetchMessages() {
       const options = useApiFetchOption();

--- a/types/workshop.ts
+++ b/types/workshop.ts
@@ -15,7 +15,7 @@ export interface Workshop {
     work_step: WorkStep;
     users: [User];
     team: Team;
-    work_date: Date;
+    work_date: string;
     work_start_time: string | null;
     turn_start_time: string | null;
   };

--- a/types/workshop.ts
+++ b/types/workshop.ts
@@ -16,5 +16,7 @@ export interface Workshop {
     users: [User];
     team: Team;
     work_date: Date;
+    work_start_time: string | null;
+    turn_start_time: string | null;
   };
 }


### PR DESCRIPTION
以下のIssueへの対処を実施
https://github.com/da-yoshi-k/huddle-guide/issues/93

https://github.com/da-yoshi-k/huddle-guide/issues/75

バグについては、Rails APIから返却された時刻の末尾にある「 +0900」という文字列が影響していた様子。
そのため、タイムゾーンの情報がある場合には削除した上でdayjsの関数を利用するように修正しました。